### PR TITLE
fix ravendb-win dockerfile - start server in the bg and import dbs

### DIFF
--- a/toolset/databases/ravendb-win/Dockerfile
+++ b/toolset/databases/ravendb-win/Dockerfile
@@ -1,22 +1,9 @@
-FROM microsoft/dotnet:runtime-nanoserver
+FROM ravendb/ravendb:windows-nanoserver-latest 
 
-ENV RAVEN_ARGS='' RAVEN_Setup_Mode='None' RAVEN_ServerUrl='http://localhost:8080' RAVEN_Security_UnsecuredAccessAllowed='PrivateNetwork' RAVEN_SETTINGS='' RAVEN_Setup_Mode='Initial' RAVEN_DataDir='RavenData' RAVEN_ServerUrl_Tcp='38888' RAVEN_AUTO_INSTALL_CA='true' RAVEN_IN_DOCKER='true'
+ENV RAVEN_ARGS='' RAVEN_SETTINGS='{}' RAVEN_Setup_Mode='None' RAVEN_ServerUrl='http://0.0.0.0:8080' RAVEN_Security_UnsecuredAccessAllowed='PrivateNetwork' RAVEN_DataDir='RavenData' RAVEN_ServerUrl_Tcp='38888' RAVEN_AUTO_INSTALL_CA='true' RAVEN_IN_DOCKER='true' RAVEN_License_Eula_Accepted='true'
 
-EXPOSE 8080 38888 161
-
-ADD https://daily-builds.s3.amazonaws.com/RavenDB-4.0.4-patch-40038-windows-x64.zip C:/RavenDB.zip
-
-COPY install-raven.ps1 C:/
-RUN powershell -c 'C:\install-raven.ps1'
-
-ADD https://ravendb-docker.s3.amazonaws.com/vcruntime140.dll C:/RavenDB/Server
-COPY TechEmpower-Fortunes.ravendbdump C:/
-COPY TechEmpower-World.ravendbdump C:/
+COPY TechEmpower-World.ravendbdump TechEmpower-Fortunes.ravendbdump C:/datadumps/
 COPY settings.json C:/RavenDB/Server
-
-VOLUME C:/RavenDB/Server/RavenData C:/RavenDB/Config
-
-WORKDIR C:/RavenDB/Server
 
 COPY run-raven.ps1 C:/
 CMD [ "powershell", "-File", "C:\\run-raven.ps1" ]


### PR DESCRIPTION
Here's the Windows version of the image. Few notes:
- I decided to use our ready-made images instead of creating a new one from scratch
- I clear the settings by settings RAVENDB_SETTINGS to `{}`, so that it only relies on ENV vars set
- drop the service installation in favor of `Start-Process -NoNewWindow`
- create dbs and import using `Invoke-WebRequest` 

For building and running I used:
`docker build . -t ravendb-bench`
`docker run -it -p 8082:8080  ravendb-bench`

Now it needs to be replicated on the linux version.