### PR TITLE
add ravendb linux image

### DIFF
--- a/toolset/databases/ravendb-linux/raven-linux.dockerfile
+++ b/toolset/databases/ravendb-linux/raven-linux.dockerfile
@@ -1,0 +1,10 @@
+
+FROM ravendb/ravendb:ubuntu-latest 
+
+ENV RAVEN_ARGS='' RAVEN_SETTINGS='{}' RAVEN_Setup_Mode='None' RAVEN_Logs_Mode='None' RAVEN_ServerUrl='http://0.0.0.0:8080' RAVEN_Security_UnsecuredAccessAllowed='PrivateNetwork' RAVEN_DataDir='RavenData' RAVEN_ServerUrl_Tcp='38888' RAVEN_AUTO_INSTALL_CA='true' RAVEN_IN_DOCKER='true' RAVEN_License_Eula_Accepted='true' RAVEN_License='{"Id": "baf49237-9991-44c3-ab0b-f05071db57f0","Name": "TechEmpower","Keys": ["tPsfEbpY71VT3mNJTMKDQ0SgZ","9VphQ7IVmdBshLNRwrmyUhpfA","oD+x83TYNuu0ffrptiBVxb4Pk","0wwjtLN45Lt3gomRE1oSrBtKu","IA6KJAHB0ZXOx33frYdgwNrgr","ibUhf5w5pXR6VnZmdjUXukw4w","XWGzvXkDg7oRbYmn3ZjGpABUE","oBSYoSQMqKywtLi8wJzFDJEQJ","Yn5N"]}'
+
+COPY TechEmpower-World.ravendbdump TechEmpower-Fortunes.ravendbdump /datadumps/
+COPY settings.json /opt/RavenDB/Server/
+COPY run-raven.sh /opt/RavenDB/run-raven.sh
+
+CMD /opt/RavenDB/run-raven.sh

--- a/toolset/databases/ravendb-linux/run-raven.sh
+++ b/toolset/databases/ravendb-linux/run-raven.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+COMMAND="./Raven.Server"
+export RAVEN_ServerUrl="http://$(hostname):8080"
+
+if [ ! -z "$RAVEN_SETTINGS" ]; then
+    echo "$RAVEN_SETTINGS" > settings.json
+fi
+
+if [ ! -z "$RAVEN_ARGS" ]; then
+	COMMAND="$COMMAND ${RAVEN_ARGS}"
+fi
+
+eval $COMMAND &
+
+function create_database () {
+    DBNAME="$1"
+    curl --fail --silent --show-error -X PUT \
+        -d "{\"DatabaseName\":\"$DBNAME\",\"Settings\":{},\"Disabled\":false,\"Encrypted\":false,\"Topology\":{\"DynamicNodesDistribution\":false}}" \
+        "$RAVEN_ServerUrl/admin/databases?name=$DBNAME&replicationFactor=1"
+}
+
+function get_import_uri () {
+    DBNAME="$1"
+    echo "$RAVEN_ServerUrl/databases/$DBNAME/admin/smuggler/import";
+}
+
+sleep 3
+
+echo
+echo "Importing data"
+
+# import dbs
+create_database "world"
+curl --fail --silent --show-error -X GET "$(get_import_uri world)?file=/datadumps/TechEmpower-World.ravendbdump"
+
+create_database "fortunes"
+curl --fail --silent --show-error -X GET "$(get_import_uri fortunes)?file=/datadumps/TechEmpower-Fortunes.ravendbdump"
+
+echo
+echo "Data imported"
+
+while true; do
+    ALIVE=`pgrep Raven.Server`;
+    if [ -z "$ALIVE" ]; then
+        exit 1;
+    fi
+
+    sleep 5;
+done

--- a/toolset/databases/ravendb-linux/settings.json
+++ b/toolset/databases/ravendb-linux/settings.json
@@ -1,0 +1,3 @@
+﻿{
+    "Security.UnsecuredAccessAllowed": "PrivateNetwork"
+}


### PR DESCRIPTION
Based on the Windows version - starts the server in the background, import data and sleeps until server dies.

I built it like so:
```
C:\work\TechEmpowerFrameworkBenchmarks\toolset\databases\ravendb-linux
λ  docker build . -f .\raven-linux.dockerfile -t ravendb-bench
...
λ docker run -p 8080:8080 ravendb-bench
```